### PR TITLE
Statements: Add UPDATE, SET, INSERT

### DIFF
--- a/QueryGenerator.php
+++ b/QueryGenerator.php
@@ -48,6 +48,11 @@ class QueryGenerator {
          'glue' => ', ',
          'suffix' => '',
       ],
+      'insert' => [
+         'prefix' => 'INSERT ',
+         'glue' => ', ',
+         'suffix' => '',
+      ],
       'set' => [
          'prefix' => 'SET ',
          'glue' => ",\n",
@@ -148,12 +153,13 @@ class QueryGenerator {
     * Returns an array containing the query and paramter list, respectively.
     */
    public function build() {
+      $insert = $this->clauses['insert'];
       $update = $this->clauses['update'];
       $select = $this->clauses['select'];
       $from = $this->clauses['from'];
-      if (!$select && !$from & !$update) {
-         throw new Exception('Query must have an UPDATE or (SELECT and FROM) clauses.');
-      } else if (!$update) {
+      if (!$select && !$from && !$update && !$insert) {
+         throw new Exception('Query must have UPDATE or INSERT or (SELECT and FROM) clauses.');
+      } else if (!$update && !$insert) {
          if (!$select) {
             throw new Exception('Query must have a SELECT clause.');
          } else if (!$from) {

--- a/QueryGeneratorTest.php
+++ b/QueryGeneratorTest.php
@@ -108,9 +108,9 @@ EOT;
    }
 
    public function testUpdateQuery() {
-      $qGen = new QueryGenerator();
-      $qGen->update('table');
-      $qGen->set('field', 'value');
+      $qGen = (new QueryGenerator())
+         ->update('table')
+         ->set('field', 'value');
       list($actualQuery, $actualParams) = $qGen->build();
 
       $expectedQuery = <<<EOT
@@ -125,6 +125,31 @@ EOT;
       list($actualQuery, $actualParams) = $qGen->build();
       $expectedQuery = <<<EOT
 UPDATE table
+SET field = ?,
+field = other_column
+EOT;
+      $this->assertEquals($actualQuery, $expectedQuery);
+      $this->assertEquals($actualParams, $expectedParams);
+   }
+
+   public function testInsertQuery() {
+      $qGen = (new QueryGenerator())
+         ->insert('table')
+         ->set('field', 'value');
+      list($actualQuery, $actualParams) = $qGen->build();
+
+      $expectedQuery = <<<EOT
+INSERT table
+SET field = ?
+EOT;
+      $expectedParams = ['value'];
+      $this->assertEquals($actualQuery, $expectedQuery);
+      $this->assertEquals($actualParams, $expectedParams);
+
+      $qGen->set('field = other_column');
+      list($actualQuery, $actualParams) = $qGen->build();
+      $expectedQuery = <<<EOT
+INSERT table
 SET field = ?,
 field = other_column
 EOT;


### PR DESCRIPTION
The tests illustrate both versions of calling ->set()

```
q->set('column', 'string value') // Lack of an '=' indicates that
                                 // 'column' is just a column name and
                                 // it is expanded to 'column = ?'

q->set('column = "string value"') // Presence of an '=' indicates a full
                                  // expression is passed and the string
                                  // will be added straight to the query
                                  // (params are still allowed)
```

INSERT functions exactly the same as UPDATE.
