### PR TITLE
Allow QueryGenerator instances to be used as args

### DIFF
--- a/QueryGenerator.php
+++ b/QueryGenerator.php
@@ -42,104 +42,122 @@ class QueryGenerator {
     */
    private static $methods = [
       'select' => [
-         'prefix' => 'SELECT <<MODIFIERS>> ',
+         'clause' => 'SELECT <<MODIFIERS>> ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'insert' => [
-         'prefix' => 'INSERT <<MODIFIERS>> INTO ',
+         'clause' => 'INSERT <<MODIFIERS>> INTO ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
       ],
       'replace' => [
-         'prefix' => 'REPLACE <<MODIFIERS>> INTO ',
+         'clause' => 'REPLACE <<MODIFIERS>> INTO ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
       ],
       'update' => [
-         'prefix' => 'UPDATE <<MODIFIERS>> ',
+         'clause' => 'UPDATE <<MODIFIERS>> ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
       ],
       'delete' => [
-         'prefix' => 'DELETE <<MODIFIERS>> ',
+         'clause' => 'DELETE <<MODIFIERS>> ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
       ],
       'from' => [
-         'prefix' => 'FROM ',
+         'clause' => 'FROM ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'join' => [
+         'clause' => '',
          'prefix' => '',
          'glue' => "\n",
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'set' => [
-         'prefix' => 'SET ',
+         'clause' => 'SET ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'columns' => [
+         'clause' => '',
          'prefix' => '(',
          'glue' => ', ',
          'suffix' => ')',
          'requiresArgument' => true,
       ],
       'values' => [
-         'prefix' => 'VALUES (',
+         'clause' => 'VALUES ',
+         'prefix' => '(',
          'glue' => '), (',
          'suffix' => ')',
          'requiresArgument' => true,
       ],
       'where' => [
-         'prefix' => 'WHERE (',
+         'clause' => 'WHERE ',
+         'prefix' => '(',
          'glue' => ') AND (',
          'suffix' => ')',
          'requiresArgument' => true,
       ],
       'group' => [
-         'prefix' => 'GROUP BY ',
+         'clause' => 'GROUP BY ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'having' => [
-         'prefix' => 'HAVING (',
+         'clause' => 'HAVING ',
+         'prefix' => '(',
          'glue' => ') AND (',
          'suffix' => ')',
          'requiresArgument' => true,
       ],
       'order' => [
-         'prefix' => 'ORDER BY ',
+         'clause' => 'ORDER BY ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'limit' => [
-         'prefix' => 'LIMIT ',
+         'clause' => 'LIMIT ',
+         'prefix' => '',
          'glue' => '',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'offset' => [
-         'prefix' => 'OFFSET ',
+         'clause' => 'OFFSET ',
+         'prefix' => '',
          'glue' => '',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'duplicate' => [
-         'prefix' => 'ON DUPLICATE KEY UPDATE ',
+         'clause' => 'ON DUPLICATE KEY UPDATE ',
+         'prefix' => '',
          'glue' => ', ',
          'suffix' => '',
          'requiresArgument' => true,
       ],
       'modify' => [
+         'clause' => '',
          'prefix' => '',
          'glue' => ' ',
          'suffix' => '',
@@ -235,6 +253,11 @@ class QueryGenerator {
          list($clauses, $params) = $args;
       }
 
+      if ($clauses instanceOf QueryGenerator) {
+         $clauses->skipValidation();
+         list($clauses, $params) = $clauses->build(/* $skipClauses = */ true);
+      }
+
       if (!is_array($clauses)) {
          $clauses = [$clauses];
       }
@@ -257,9 +280,13 @@ class QueryGenerator {
     * (one of MissingPrimaryClauseException or MissingRequiredClauseException)
     * unless `skipValidation` has been called.
     *
+    * @param $skipClauses : Exclude the 'clause' part (WHERE, SELECT, FROM, 
+    *                       ...) of each sub-expression. See constructClause 
+    *                       for more info. This is mostly for internal usage.
+    *
     * Returns an array containing the query and paramter list, respectively.
     */
-   public function build() {
+   public function build($skipClauses = false) {
       if ($this->validateQuery) {
          $this->assertCompleteQuery();
       }
@@ -279,7 +306,7 @@ class QueryGenerator {
             continue;
          }
 
-         $clauses[] = $this->constructClause($method);
+         $clauses[] = $this->constructClause($method, $skipClauses);
          $params = array_merge($params, $this->params[$method]);
       }
       return [implode("\n", $clauses), $params];
@@ -363,28 +390,34 @@ class QueryGenerator {
    }
 
    /**
-    * Return a string of the specified SQL clause using its syntax rules.
+    * Return a string of the specified SQL clause using its syntax rules, 
+    * optionally excluding the clause part (i.e. WHERE, SELECT, ...)
     *
     * Example:
     *    given where clauses 'foo = ?' and 'bar != ?'
     *    constructClause('where') => 'WHERE (foo = ?) AND (bar != ?)'
+    *    constructClause('where', false) => '(foo = ?) AND (bar != ?)'
     */
-   private function constructClause($method) {
-      $prefix = self::$methods[$method]['prefix'];
+   private function constructClause($method, $skipClause = false) {
+      $clauseInfo = self::$methods[$method];
+      $prefix = $clauseInfo['prefix'];
+      $clause = $clauseInfo['clause'];
 
+      if ($skipClause) {
+         $clause = '';
       // The assumed precondition is that modify's prefix element will never
       // contain the substring '<<MODIFIERS>>'.
-      if (strpos($prefix, '<<MODIFIERS>>') !== false) {
-         $prefix = str_replace('<<MODIFIERS>>', $this->constructClause('modify'), $prefix);
+      } else if (strpos($clause, '<<MODIFIERS>>') !== false) {
+         $clause = str_replace('<<MODIFIERS>>', $this->constructClause('modify'), $clause);
          // If there are no modifiers to apply we end up with an extra space
          // after the primary verb.
-         $prefix = str_replace('  ', ' ', $prefix);
+         $clause = str_replace('  ', ' ', $clause);
       }
 
-      $suffix = self::$methods[$method]['suffix'];
+      $suffix = $clauseInfo['suffix'];
       $glue = $this->getGlue($method);
       $pieces = implode($glue, $this->clauses[$method]);
-      return "$prefix$pieces$suffix";
+      return "$clause$prefix$pieces$suffix";
    }
 
    /**

--- a/QueryGeneratorTest.php
+++ b/QueryGeneratorTest.php
@@ -161,6 +161,24 @@ EOT;
       $this->assertQuery($qGen, $expectedQuery, $expectedParams);
    }
 
+   public function testNestedGenerators() {
+      $where = new QueryGenerator();
+      $where->where('abcd', [1]);
+      $qGen = new QueryGenerator();
+      $qGen->select('field');
+      $qGen->from('table');
+      $qGen->where($where);
+
+      $expectedQuery = <<<EOT
+SELECT field
+FROM table
+WHERE ((abcd))
+EOT;
+      $expectedParams = [1];
+
+      $this->assertQuery($qGen, $expectedQuery, $expectedParams);
+   }
+
    public function testSingleArguments() {
       $qGen = new QueryGenerator();
       $qGen->select('field');


### PR DESCRIPTION
So you can build sub expressions or sub queries:

```
$q = new QueryGenerator()->useOr()->where("x")->where("y")
$b = new QueryGenerator()->where($q)->where("z");

$b->build() == ["WHERE ((x) OR (y)) AND (z)",[]];
```

It's also useful if you just want to create a part of a query for use
elsewhere.

```
new QueryGenerator()->where("z")->build(true) == ["(z)", []];
```
