### PR TITLE
MySQL 8 adds aliases to INSERT statements, allow that

### DIFF
--- a/QueryGenerator.php
+++ b/QueryGenerator.php
@@ -149,6 +149,13 @@ class QueryGenerator {
          'suffix' => '',
          'requiresArgument' => true,
       ],
+      'as' => [
+         'clause' => 'AS ',
+         'prefix' => '',
+         'glue' => false,
+         'suffix' => '',
+         'requiresArgument' => true,
+      ],
       'duplicate' => [
          'clause' => 'ON DUPLICATE KEY UPDATE ',
          'prefix' => '',
@@ -179,7 +186,7 @@ class QueryGenerator {
     */
    private static $possibleClauses = [
       'select' => ['from', 'join', 'where', 'group', 'having', 'order', 'limit', 'offset', 'forupdate'],
-      'insert' => ['set', 'columns', 'values', 'duplicate'],
+      'insert' => ['set', 'columns', 'values', 'duplicate', 'as'],
       'replace' => ['set', 'columns', 'values'],
       'update' => ['set', 'where', 'order', 'limit'],
       'delete' => ['from', 'where', 'order', 'limit'],
@@ -271,6 +278,10 @@ class QueryGenerator {
 
       if (!is_array($params)) {
          $params = [$params];
+      }
+
+      if (self::$methods[$method]['glue'] === false && count($this->clauses[$method]) > 1) {
+         throw new Exception("Only one '$method()' is allowed per query");
       }
 
       $this->clauses[$method] = array_merge($this->clauses[$method], $clauses);

--- a/QueryGeneratorTest.php
+++ b/QueryGeneratorTest.php
@@ -226,6 +226,7 @@ EOT;
    public function testOnDuplicate() {
       $qGen = new QueryGenerator();
       $qGen->insert('a');
+      $qGen->as('row');
       $qGen->set('b = 1');
       $qGen->set('c = 1');
       $qGen->duplicate('b = 2');
@@ -233,6 +234,7 @@ EOT;
       $expectedQuery = <<<EOT
 INSERT INTO a
 SET b = 1, c = 1
+AS row
 ON DUPLICATE KEY UPDATE b = 2
 EOT;
 


### PR DESCRIPTION
It also deprecates the VALUES(column) function in favor of adding the
newly minted aliases.

INSERT INTO x (a,b,c) VALUES (1, 2, 3) AS new_row
ON DUPLICATE KEY b = new_row.b;