### PR TITLE
QueryGenerator: Add debug output

### DIFF
--- a/QueryGenerator.php
+++ b/QueryGenerator.php
@@ -453,7 +453,7 @@ class QueryGenerator {
    /**
     * Debug method to print out the full query with the params inserted at the correct locations
     */
-   public function debugStringifyQuery(): string {
+   public function toDebugString(): string {
       [$query, $params] = $this->build();
       $chunks = array_chunk($params, 2);
       $paramValues = array_map(function ($chunk) {

--- a/QueryGenerator.php
+++ b/QueryGenerator.php
@@ -449,6 +449,31 @@ class QueryGenerator {
          return ") OR (";
       }
    }
+
+   /**
+    * Debug method to print out the full query with the params inserted at the correct locations
+    */
+   public function debugStringifyQuery(): string {
+      $query = $this->build(true);
+      $params = $query[1];
+      $paramValues = array_reduce($params, function ($carry, $param) {
+         static $isInt = false;
+
+         if ($param === 'i') {
+             $isInt = true;
+         } elseif ($param === 's') {
+             $isInt = false;
+         } else {
+             $carry[] = $isInt ? (int)$param : "'$param'";
+         }
+
+         return $carry;
+      }, []);
+      $query = $query[0];
+      $query = str_replace('?', '%s', $query);
+      $query = vsprintf($query, $paramValues);
+      return $query;
+   }
 }
 
 class MissingClauseException extends Exception {}


### PR DESCRIPTION
## Overview
I always find myself wondering what the resulting QueryGenerator query looks like when using or debugging QueryGenerators. This adds a function to build the query and substitute the params in so we get a fully runnable stringified SQL query. 

## QA
Qa_req 0 - this isn't used anywhere at the moment, and from my initial testing it works for queries with both string and integer parameters.